### PR TITLE
Feature/snapshots

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,6 +56,11 @@ RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | b
   composer global require 10up/wpsnapshots && \
   wp package install https://github.com/dustinrue/wpsnapshots/archive/refs/tags/3.0alpha1.zip && \
   echo "export PATH=$(composer global config bin-dir --absolute -q):$PATH" >> ~/.bashrc
+RUN \
+  curl -o /tmp/snapshots.zip https://codeload.github.com/10up/snapshots/zip/refs/tags/1.0.0 && \
+  wp package install /tmp/snapshots.zip && \
+  rm -f /tmp/snapshots.zip
+
 WORKDIR /var/www/html
 
 ENTRYPOINT []

--- a/README.md
+++ b/README.md
@@ -83,3 +83,4 @@ Xdebug can be very slow on some systems. By default, xdebug will not be loaded. 
 <p align="center">
 <a href="http://10up.com/contact/"><img src="https://10up.com/uploads/2016/10/10up-Github-Banner.png" width="850"></a>
 </p>
+


### PR DESCRIPTION
This change brings in the wp-cli package "10up/snapshots" to allow testing and/or usage from within wp-local-docker as well as other solutions.